### PR TITLE
Refactor to a button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -17,76 +17,27 @@
 	}
 }
 
-#night-day-toggle {
+#dark-mode-toggler {
 	cursor: pointer;
 	position: fixed;
 	bottom: 5px;
 	right: 5px;
-	padding: 5px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	z-index: 999999;
+	font-size: var(--global--font-size-xs);
+	padding: 0.5em;
+	min-height: 44px; /* a11y requirement for minimum clickable area. */
+	min-width: 44px; /* a11y requirement for minimum clickable area. */
+	border: 2px solid var(--button--color-background);
+	box-shadow: none;
+	background: var(--button--color-background);
+	color: var(--button--color-text);
 }
 
-#night-day-toggle input {
-	width: 1px;
-	height: 1px;
-	opacity: 0;
-	overflow: hidden;
-	position: absolute;
-}
-
-#night-day-toggle *,
-#night-day-toggle *:after,
-#night-day-toggle *:before {
-	box-sizing: border-box;
-}
-
-#night-day-toggle label {
-	position: relative;
-	display: block;
-	width: 60px;
-	height: 33px;
-	border-radius: 33px;
-	background-color: currentColor;
-	overflow: hidden;
-	cursor: pointer;
-	margin: 0;
-}
-
-#night-day-toggle label:before,
-#night-day-toggle label:after {
-	display: block;
-	position: absolute;
-	content: "";
-	width: 24px;
-	height: 24px;
-	border-radius: 50%;
-	top: 4.5px;
-	left: 4.5px;
-	transition: .1s ease-in-out;
-}
-
-#night-day-toggle label:before {
-	background-color: var(--global--color-background);
-}
-
-#night-day-toggle label:after {
-	background-color: currentColor;
-	left: -19px;
-	transform: scale(0.00001);
-}
-
-#night-day-toggle input[type="checkbox"]:checked + label:before {
-	background-color: var(--global--color-background);
-	transform: translateX(27px);
-}
-
-#night-day-toggle input[type="checkbox"]:checked + label:after {
-	transform: translateX(40px) scale(1);
-}
-
-#night-day-toggle.focused {
-	box-shadow: 0 0 0 2px currentColor;
+#dark-mode-toggler:hover,
+#dark-mode-toggler:focus {
+	color: var(--button--color-text-active);
+	border: 2px solid var(--button--color-text-active);
+	background-color: var(--button--color-background-active);
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -19,9 +19,6 @@
 
 #dark-mode-toggler {
 	cursor: pointer;
-	position: fixed;
-	bottom: 5px;
-	right: 5px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -34,6 +31,12 @@
 	background: var(--button--color-background);
 	color: var(--button--color-text);
 	z-index: 9999; /* Necessary for the editor. */
+}
+
+#dark-mode-toggler.fixed-bottom {
+	position: fixed;
+	bottom: 5px;
+	right: 5px;
 }
 
 #dark-mode-toggler:hover,

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -28,11 +28,12 @@
 	font-size: var(--global--font-size-xs);
 	padding: 0.5em;
 	min-height: 44px; /* a11y requirement for minimum clickable area. */
-	min-width: 44px; /* a11y requirement for minimum clickable area. */
+	min-width: max-content;
 	border: 2px solid var(--button--color-background);
 	box-shadow: none;
 	background: var(--button--color-background);
 	color: var(--button--color-text);
+	z-index: 9999; /* Necessary for the editor. */
 }
 
 #dark-mode-toggler:hover,

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -39,6 +39,30 @@
 	right: 5px;
 }
 
+#dark-mode-toggler.relative {
+	position: absolute;
+	height: 44px;
+	top: calc(2.4 * var(--global--spacing-vertical) - 44px);
+	right: calc(50vw - var(--responsive--alignwide-width) / 2);
+}
+
+.admin-bar #dark-mode-toggler.relative {
+	top: calc(2.4 * var(--global--spacing-vertical) - 44px + 32px);
+}
+
+@media only screen and (max-width: 782px) {
+	.admin-bar #dark-mode-toggler.relative {
+		top: calc(2.4 * var(--global--spacing-vertical) - 44px + 46px);
+	}
+}
+
+@media only screen and (max-width: 481px) {
+
+	#dark-mode-toggler.relative ~ nav {
+		top: 86px;
+	}
+}
+
 #dark-mode-toggler:hover,
 #dark-mode-toggler:focus {
 	color: var(--button--color-text-active);

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -43,7 +43,7 @@
 	position: absolute;
 	height: 44px;
 	top: calc(2.4 * var(--global--spacing-vertical) - 44px);
-	right: calc(50vw - var(--responsive--alignwide-width) / 2);
+	right: calc(50vw - var(--responsive--alignwide-width) / 2 - 0.5em);
 }
 
 .admin-bar #dark-mode-toggler.relative {

--- a/assets/js/editor-dark-mode-support.js
+++ b/assets/js/editor-dark-mode-support.js
@@ -54,7 +54,7 @@ function twentytwentyoneDarkModeEditorToggle() {
  * @return {void}
  */
 function twentytwentyoneDarkModeEditorToggleEditorStyles() {
-	var toggler = document.getElementById( 'dark-mode-toggler' )
+	var toggler = document.getElementById( 'dark-mode-toggler' );
 
 	if ( 'true' === toggler.getAttribute( 'aria-pressed' ) ) {
 		document.body.classList.add( 'is-dark-theme' );

--- a/assets/js/editor-dark-mode-support.js
+++ b/assets/js/editor-dark-mode-support.js
@@ -1,4 +1,4 @@
-/* global ajaxurl, XMLHttpRequest, ResizeObserver, toggleDarkMode */
+/* global ajaxurl, XMLHttpRequest, ResizeObserver, darkModeInitialLoad */
 
 // Check the body class to determine if we want to add the toggler and handle dark-mode or not.
 if ( document.body.classList.contains( 'twentytwentyone-supports-dark-theme' ) ) {
@@ -35,7 +35,7 @@ function twentytwentyoneDarkModeEditorToggle() {
 			twentytwentyoneDarkModeEditorTogglePositionObserver();
 
 			// Run toggler script.
-			toggleDarkMode();
+			darkModeInitialLoad();
 
 			// Switch editor styles if needed.
 			twentytwentyoneDarkModeEditorToggleEditorStyles();
@@ -77,15 +77,15 @@ function twentytwentyoneDarkModeEditorToggleEditorStyles() {
  * @return {void}
  */
 function twentytwentyoneDarkModeEditorTogglePosition() {
-	var toggle = document.getElementById( 'night-day-toggle' ),
+	var toggle = document.getElementById( 'dark-mode-toggler' ),
+		toggleWidth = window.getComputedStyle( document.getElementById( 'dark-mode-toggler' ) ).width,
 		workSpace = document.querySelector( '.editor-styles-wrapper' ),
 		workSpaceWidth = window.getComputedStyle( workSpace ).width;
 
 	// Add styles to reposition toggle.
 	toggle.style.position = 'fixed';
 	toggle.style.bottom = '30px';
-	toggle.style.width = '70px';
-	toggle.style.left = 'calc(' + workSpaceWidth + ' - 100px)';
+	toggle.style.left = 'calc(' + workSpaceWidth + ' - ' + toggleWidth + ' - 5px)';
 }
 
 /**

--- a/assets/js/editor-dark-mode-support.js
+++ b/assets/js/editor-dark-mode-support.js
@@ -54,14 +54,14 @@ function twentytwentyoneDarkModeEditorToggle() {
  * @return {void}
  */
 function twentytwentyoneDarkModeEditorToggleEditorStyles() {
-	var input = document.querySelector( '#night-day-toggle input' );
+	var toggler = document.getElementById( 'dark-mode-toggler' )
 
-	if ( input.checked ) {
+	if ( 'true' === toggler.getAttribute( 'aria-pressed' ) ) {
 		document.body.classList.add( 'is-dark-theme' );
 	}
 
-	input.addEventListener( 'change', function() {
-		if ( this.checked ) {
+	toggler.addEventListener( 'click', function() {
+		if ( 'true' === toggler.getAttribute( 'aria-pressed' ) ) {
 			document.body.classList.add( 'is-dark-theme' );
 		} else {
 			document.body.classList.remove( 'is-dark-theme' );

--- a/assets/js/editor-dark-mode-support.js
+++ b/assets/js/editor-dark-mode-support.js
@@ -1,4 +1,4 @@
-/* global ajaxurl, XMLHttpRequest, ResizeObserver, twentytwentyoneNightDayToggler */
+/* global ajaxurl, XMLHttpRequest, ResizeObserver, toggleDarkMode */
 
 // Check the body class to determine if we want to add the toggler and handle dark-mode or not.
 if ( document.body.classList.contains( 'twentytwentyone-supports-dark-theme' ) ) {
@@ -35,7 +35,7 @@ function twentytwentyoneDarkModeEditorToggle() {
 			twentytwentyoneDarkModeEditorTogglePositionObserver();
 
 			// Run toggler script.
-			twentytwentyoneNightDayToggler();
+			toggleDarkMode();
 
 			// Switch editor styles if needed.
 			twentytwentyoneDarkModeEditorToggleEditorStyles();

--- a/assets/js/toggler.js
+++ b/assets/js/toggler.js
@@ -1,7 +1,22 @@
-function twentytwentyoneNightDayToggler() {
-	var toggler = document.getElementById( 'night-day-toggle-input' ),
-		isDarkMode = window.matchMedia( '(prefers-color-scheme: dark)' ).matches,
+function toggleDarkMode() {
+	var toggler = document.getElementById( 'dark-mode-toggler' ),
 		html = document.querySelector( 'html' );
+
+	if ( 'false' === toggler.getAttribute( 'aria-pressed' ) ) {
+		toggler.setAttribute( 'aria-pressed', 'true' );
+		html.classList.add( 'respect-color-scheme-preference' );
+		window.localStorage.setItem( 'twentytwentyoneDarkMode', 'yes' );
+	} else {
+		toggler.setAttribute( 'aria-pressed', 'false' );
+		html.classList.remove( 'respect-color-scheme-preference' );
+		window.localStorage.setItem( 'twentytwentyoneDarkMode', 'no' );
+	}
+}
+
+function darkModeInitialLoad() {
+	var toggler = document.getElementById( 'dark-mode-toggler' ),
+		isDarkMode = window.matchMedia( '(prefers-color-scheme: dark)' ).matches,
+		html;
 
 	if ( 'yes' === window.localStorage.getItem( 'twentytwentyoneDarkMode' ) ) {
 		isDarkMode = true;
@@ -13,31 +28,15 @@ function twentytwentyoneNightDayToggler() {
 		return;
 	}
 	if ( isDarkMode ) {
-		toggler.checked = true;
+		toggler.setAttribute( 'aria-pressed', 'true' );
 	}
 
+	html = document.querySelector( 'html' );
 	if ( isDarkMode ) {
 		html.classList.add( 'respect-color-scheme-preference' );
 	} else {
 		html.classList.remove( 'respect-color-scheme-preference' );
 	}
-
-	toggler.addEventListener( 'click', function() {
-		if ( toggler.checked ) {
-			html.classList.add( 'respect-color-scheme-preference' );
-			window.localStorage.setItem( 'twentytwentyoneDarkMode', 'yes' );
-		} else {
-			html.classList.remove( 'respect-color-scheme-preference' );
-			window.localStorage.setItem( 'twentytwentyoneDarkMode', 'no' );
-		}
-	} );
-
-	toggler.addEventListener( 'focus', function() {
-		document.getElementById( 'night-day-toggle' ).classList.add( 'focused' );
-	} );
-
-	toggler.addEventListener( 'blur', function() {
-		document.getElementById( 'night-day-toggle' ).classList.remove( 'focused' );
-	} );
 }
-twentytwentyoneNightDayToggler();
+
+darkModeInitialLoad();

--- a/assets/js/toggler.js
+++ b/assets/js/toggler.js
@@ -1,4 +1,4 @@
-function toggleDarkMode() {
+function toggleDarkMode() { // eslint-disable-line no-unused-vars
 	var toggler = document.getElementById( 'dark-mode-toggler' ),
 		html = document.querySelector( 'html' );
 

--- a/functions.php
+++ b/functions.php
@@ -207,11 +207,13 @@ add_action( 'get_template_part_template-parts/header/site-branding', 'tt1_the_da
  *
  * @since 1.0.0
  *
+ * @param string $classes The classes to add.
+ *
  * @return void
  */
-function tt1_dark_mode_switch_the_html() {
+function tt1_dark_mode_switch_the_html( $classes = 'fixed-bottom' ) {
 	?>
-	<button id="dark-mode-toggler" aria-pressed="false" onClick="toggleDarkMode()">
+	<button id="dark-mode-toggler" class="<?php echo esc_attr( $classes ); ?>" aria-pressed="false" onClick="toggleDarkMode()">
 		<?php
 		printf(
 			esc_html__( 'Dark theme: %s', 'twentytwentyone-dark-mode' ),

--- a/functions.php
+++ b/functions.php
@@ -197,7 +197,7 @@ function tt1_the_dark_mode_switch() {
 	tt1_dark_mode_switch_the_html();
 	tt1_dark_mode_switch_the_script();
 }
-add_action( 'wp_footer', 'tt1_the_dark_mode_switch' );
+add_action( 'get_template_part_template-parts/header/site-branding', 'tt1_the_dark_mode_switch' );
 
 
 /**
@@ -211,12 +211,19 @@ add_action( 'wp_footer', 'tt1_the_dark_mode_switch' );
  */
 function tt1_dark_mode_switch_the_html() {
 	?>
-	<div id="night-day-toggle">
-		<input type="checkbox" id="night-day-toggle-input"/>
-		<label for="night-day-toggle-input">
-			<span class="screen-reader-text"><?php esc_html_e( 'Toggle color scheme', 'twentytwentyone-dark-mode' ); ?></span>
-		</label>
-	</div>
+	<button id="dark-mode-toggler" aria-pressed="false" onClick="toggleDarkMode()">
+		<?php
+		printf(
+			esc_html__( 'Dark theme: %s', 'twentytwentyone-dark-mode' ),
+			'<span aria-hidden="true"></span>'
+		);
+		?>
+	</button>
+	<style>
+		#dark-mode-toggler > span::before { content: '<?php esc_attr_e( 'off', 'twentytwentyone-dark-mode' ); ?>'; }
+		#dark-mode-toggler[aria-pressed="true"] > span::before { content: '<?php esc_attr_e( 'on', 'twentytwentyone-dark-mode' ); ?>'; }
+	</style>
+
 	<?php
 }
 

--- a/functions.php
+++ b/functions.php
@@ -197,7 +197,7 @@ function tt1_the_dark_mode_switch() {
 	tt1_dark_mode_switch_the_html();
 	tt1_dark_mode_switch_the_script();
 }
-add_action( 'get_template_part_template-parts/header/site-branding', 'tt1_the_dark_mode_switch' );
+add_action( 'get_template_part_template-parts/header/site-nav', 'tt1_the_dark_mode_switch' );
 
 
 /**
@@ -211,7 +211,7 @@ add_action( 'get_template_part_template-parts/header/site-branding', 'tt1_the_da
  *
  * @return void
  */
-function tt1_dark_mode_switch_the_html( $classes = 'fixed-bottom' ) {
+function tt1_dark_mode_switch_the_html( $classes = 'relative' ) {
 	?>
 	<button id="dark-mode-toggler" class="<?php echo esc_attr( $classes ); ?>" aria-pressed="false" onClick="toggleDarkMode()">
 		<?php


### PR DESCRIPTION
Collaborated with @afercia on an a11y-first approach. The result of that was an implementation inspired by https://inclusive-components.design/a-theme-switcher/ and it's a button injected right before the main navigation, which switches the color-scheme:

![animated demonstration of the button working](https://user-images.githubusercontent.com/588688/97558372-b1bb1d80-19e4-11eb-8e66-17757865bca6.gif)

![animated demonstration of the button working on a small screen in conjunction with the mobile-menu toggler](https://user-images.githubusercontent.com/588688/97560008-d0221880-19e6-11eb-9fb7-5b96d8811fc1.gif)

Also see #1 